### PR TITLE
Progress stats rework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.pyc
 *.anki2
 .pytest_cache
+meta.json

--- a/progress_stats/__init__.py
+++ b/progress_stats/__init__.py
@@ -11,3 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from .graphs import *

--- a/progress_stats/graphs.py
+++ b/progress_stats/graphs.py
@@ -62,7 +62,7 @@ def progressGraphs(self):
     bucket_size_days=bucket_size_days, num_buckets=num_buckets,
     day_cutoff_seconds=self.col.sched.dayCutoff, additional_filter=self._revlogLimit())
 
-  result = old(self)
+  result = ""
 
   result += _plot(self,
               stats["learned_cards"],

--- a/progress_stats/graphs.py
+++ b/progress_stats/graphs.py
@@ -14,8 +14,10 @@
 
 import json
 import math
-from progress_stats.compute import get_stats
-
+from .compute import get_stats
+import anki.stats
+from anki.hooks import wrap
+from anki.statsbg import bg
 
 colYoung = "#7c7"
 colMature = "#070"

--- a/progress_stats/graphs.py
+++ b/progress_stats/graphs.py
@@ -24,11 +24,27 @@ defaultColor = "#0F0"
 
 _num_graphs = 0
 
+def report_alt(self, type=0):
+    # 0=days, 1=weeks, 2=months
+    self.type = type
+    txt = self.css % bg
+    txt += self._section(self.todayStats())
+    txt += self._section(self.dueGraph())
+    txt += self.repsGraphs()
+    txt += self._section(self.introductionGraph())
+    txt += self._section(self.ivlGraph())
+    txt += self._section(self.hourGraph())
+    txt += self._section(self.easeGraph())
+    txt += self._section(self.cardGraph())
+    txt += self._section(self.progressGraphs())
+    txt += self._section(self.footer())
+    return "<center>%s</center>" % txt
 
-def progressGraphs(*args, **kwargs):
-  self = args[0]
-  old = kwargs['_old']
+anki.stats.CollectionStats.report = \
+  wrap(anki.stats.CollectionStats.report, report_alt, pos="after")
 
+
+def progressGraphs(self):
   if self.type == 0:
     num_buckets = 30
     bucket_size_days = 1

--- a/progress_stats/graphs.py
+++ b/progress_stats/graphs.py
@@ -141,52 +141,52 @@ def _graph(self, id, data, conf={},
 
         #conf['legend'] = dict(show=False)
     return (
-"""
-<table cellpadding=0 cellspacing=10>
-<tr>
+        """
+        <table cellpadding=0 cellspacing=10>
+        <tr>
 
-<td><div style="width: 150px; text-align: center; position:absolute;
- -webkit-transform: rotate(-90deg) translateY(-85px);
-font-weight: bold;
-">%(ylab)s</div></td>
+        <td><div style="width: 150px; text-align: center; position:absolute;
+         -webkit-transform: rotate(-90deg) translateY(-85px);
+        font-weight: bold;
+        ">%(ylab)s</div></td>
 
-<td>
-<center><div id=%(id)sLegend></div></center>
-<div id="%(id)s" style="width:%(w)spx; height:%(h)spx;"></div>
-</td>
+        <td>
+        <center><div id=%(id)sLegend></div></center>
+        <div id="%(id)s" style="width:%(w)spx; height:%(h)spx;"></div>
+        </td>
 
-<td><div style="width: 150px; text-align: center; position:absolute;
- -webkit-transform: rotate(90deg) translateY(65px);
-font-weight: bold;
-">%(ylab2)s</div></td>
+        <td><div style="width: 150px; text-align: center; position:absolute;
+         -webkit-transform: rotate(90deg) translateY(65px);
+        font-weight: bold;
+        ">%(ylab2)s</div></td>
 
-</tr></table>
-<script>
-$(function () {
-    var conf = %(conf)s;
-    if (conf.timeTicks) {
-        conf.xaxis.tickFormatter = function (val, axis) {
-            return val.toFixed(0)+conf.timeTicks;
-        }
-    }
-    conf.yaxis.minTickSize = 1;
-    // prevent ticks from having decimals, choose whole numbers instead
-    conf.yaxis.tickDecimals = 0;
-    conf.yaxis.tickFormatter = function (val, axis) {
-            // include the decimal if val isn't a whole number
-            return val === Math.round(val) ? val.toFixed(0) : val.toFixed(1);
-    }
-    if (conf.series.pie) {
-        conf.series.pie.label.formatter = function(label, series){
-            return '<div class=pielabel>'+Math.round(series.percent)+'%%</div>';
-        };
-    }
-    $.plot($("#%(id)s"), %(data)s, conf);
-});
-</script>""" % dict(
-    id=id, w=width, h=height,
-    ylab=ylabel, ylab2=ylabel2,
-    data=json.dumps(data), conf=json.dumps(conf)))
+        </tr></table>
+        <script>
+        $(function () {
+            var conf = %(conf)s;
+            if (conf.timeTicks) {
+                conf.xaxis.tickFormatter = function (val, axis) {
+                    return val.toFixed(0)+conf.timeTicks;
+                }
+            }
+            conf.yaxis.minTickSize = 1;
+            // prevent ticks from having decimals, choose whole numbers instead
+            conf.yaxis.tickDecimals = 0;
+            conf.yaxis.tickFormatter = function (val, axis) {
+                    // include the decimal if val isn't a whole number
+                    return val === Math.round(val) ? val.toFixed(0) : val.toFixed(1);
+            }
+            if (conf.series.pie) {
+                conf.series.pie.label.formatter = function(label, series){
+                    return '<div class=pielabel>'+Math.round(series.percent)+'%%</div>';
+                };
+            }
+            $.plot($("#%(id)s"), %(data)s, conf);
+        });
+        </script>""" % dict(
+            id=id, w=width, h=height,
+            ylab=ylabel, ylab2=ylabel2,
+            data=json.dumps(data), conf=json.dumps(conf)))
 
 
 def _plot(self, data, title, subtitle, bucket_size_days,

--- a/progress_stats/graphs.py
+++ b/progress_stats/graphs.py
@@ -96,6 +96,7 @@ def progressGraphs(self):
 
   return result
 
+anki.stats.CollectionStats.progressGraphs = progressGraphs
 
 def _round_up_max(max_val):
   "Rounds up a maximum value."


### PR DESCRIPTION
I've been working on an addon of my own, which alters the native cardGraph function to add more colors to the corresponding pie graph. However, I can't seem to overlap your add-on with mine without totally overriding the other. E.g. I can get the color change to work, but your charts will disappear, and vice-versa. 

I've tried finagling my beta code as much as possible to make it work, but after trial and error figured it'd just be best to adapt your code into an entirely new section (progressGraphs), rather than an addendum to cardGraph as it currently stands.

I've run this updated below code in beta alongside mine, and they both seem to work fine. Further, we might be able to prevent future overlap issues in current (or future) anki addons that might run into this same issue with cardGraph mods.