### PR TITLE
Set absolute maximum value of cumulative line as ymax

### DIFF
--- a/progress_stats/graphs.py
+++ b/progress_stats/graphs.py
@@ -221,7 +221,7 @@ def _plot(self, data, title, subtitle, bucket_size_days,
   yaxes = [dict(min=0, max=max_yaxis)]
 
   if include_cumulative:
-    yaxes.append(dict(min=0, max=_round_up_max(cumulative_total), position="right"))
+    yaxes.append(dict(min=0, max=_round_up_max(max(y for x, y in cumulative_data)), position="right"))
 
   txt += _graph(
     self,


### PR DESCRIPTION
Hey Matthew, thank you for publishing your helpful add-on. I've used it regularly in the past years. Lately I'm in the unfortunate situation that my net matured card count is actually decreasing. This causes the cumulative line to be partially out of bounds because the "ymax" value is set to the last point of the cumulative value. This patch changes the ymax limit to be set to the absolute maximum of the curve.